### PR TITLE
Improve types for subscribe callback return values

### DIFF
--- a/examples/transient-update-resize-observer/src/App.tsx
+++ b/examples/transient-update-resize-observer/src/App.tsx
@@ -12,7 +12,9 @@ const ResizeObserverSetup = (_: unknown, adapter: ReactAdapter) => {
 
   const unsub = $element.subscribe((element) => {
     observer.observe(element)
-    const unsub = $xy.subscribe((xy) => (element.innerHTML = xy))
+    const unsub = $xy.subscribe((xy) => {
+      element.innerHTML = xy
+    })
     return () => {
       unsub()
       observer.unobserve(element)

--- a/packages/xoid/src/types.tsx
+++ b/packages/xoid/src/types.tsx
@@ -1,20 +1,24 @@
+declare const voidOnly: unique symbol
+type Destructor = () => void | { [voidOnly]: never }
+
 export type Atom<T> = {
   value: T
   set(state: T): void
   update(fn: (state: T) => T): void
-  subscribe(fn: (state: T, prevState: T) => unknown): () => void
-  watch(fn: (state: T, prevState: T) => unknown): () => void
+  subscribe(fn: (state: T, prevState: T) => void | Destructor): () => void
+  watch(fn: (state: T, prevState: T) => void | Destructor): () => void
   focus<U>(fn: (state: T) => U): Atom<U>
   focus<U extends keyof T>(key: U): Atom<T[U]>
   map<U>(fn: (state: T, prevState: T) => U): Atom<U>
   map<U>(fn: (state: T, prevState: T) => U, filterOutFalsyValues: true): Stream<Truthy<U>>
 }
+
 export type Stream<T> = {
   value: T | undefined
   set(state: T): void
   update(fn: (state: T | undefined) => T): void
-  subscribe(fn: (state: T, prevState: T | undefined) => unknown): () => void
-  watch(fn: (state: T | undefined, prevState: T | undefined) => unknown): () => void
+  subscribe(fn: (state: T, prevState: T | undefined) => void | Destructor): () => void
+  watch(fn: (state: T | undefined, prevState: T | undefined) => void | Destructor): () => void
   focus<U>(fn: (state: T) => U): Stream<U>
   focus<U extends keyof T>(key: U): Stream<T[U]>
   map<U>(fn: (state: T, prevState: T | undefined) => U): Stream<U>


### PR DESCRIPTION
This helps better "document" the optional cleanup callback behavior as well as catch potential mistakes. The React `useEffect`, et al hook types similarly have these typing constraints, so this helps with consistency.

**Note:** I think this is nice to have, but won't be offended at all if you disagree and just close this PR. 😀