### PR TITLE
Fix mapped unsubscribe affecting other subscribers

### DIFF
--- a/packages/xoid/src/internal/utils.tsx
+++ b/packages/xoid/src/internal/utils.tsx
@@ -145,8 +145,8 @@ export const createStream =
         const unsub = internal.subscribe(listener)
         const unsub2 = nextInternal.subscribe(fn)
         return () => {
-          unsub()
           unsub2()
+          if (!nextInternal.listeners.size) unsub()
         }
       },
     })

--- a/tests/stream.test.tsx
+++ b/tests/stream.test.tsx
@@ -107,3 +107,26 @@ it('Never evaluate dependents of streams unless the stream value is satisfied', 
 
   expect(fn).toBeCalledTimes(1)
 })
+
+it('Continue notifying dependent subscriber after another one is unsubscribed', () => {
+  const fn = jest.fn()
+  const fn1 = jest.fn()
+
+  const sourceAtom = create<{ deep: { value: number } }>()
+  const derivedAtom = sourceAtom.map((state) => state.deep.value)
+
+  derivedAtom.subscribe(fn)
+  const unsub = derivedAtom.subscribe(fn1)
+
+  sourceAtom.set({ deep: { value: 5 } })
+
+  expect(fn).toBeCalledTimes(1)
+  expect(fn1).toBeCalledTimes(1)
+
+  unsub()
+
+  sourceAtom.set({ deep: { value: 6 } })
+
+  expect(fn).toBeCalledTimes(2)
+  expect(fn1).toBeCalledTimes(1)
+})


### PR DESCRIPTION
This fixes an issue where if a mapped atom is subscribed multiple times, then unsubscribed by one, it would effectively unsubscribe the others because the `listener` callback would only get added to the parent atom's listener set once. Now it'll only get removed if there are no subscribers to the derived atom remaining.