### PR TITLE
Proposal: Add get() method to Atoms

### DIFF
--- a/docs/advanced-concepts.md
+++ b/docs/advanced-concepts.md
@@ -49,6 +49,7 @@ Here's the difference of the two, from the `index.d.ts` file of **xoid**.
 ```js
 export type Atom<T> = {
   value: T
+  get(): T
   set(state: T): void
   update(fn: (state: T) => T): void
   subscribe(fn: (state: T, prevState: T) => unknown): () => void
@@ -61,6 +62,7 @@ export type Atom<T> = {
 
 export type Stream<T> = {
   value: T | undefined
+  get(): T | undefined
   set(state: T): void
   update(fn: (state: T | undefined) => T): void
   subscribe(fn: (state: T, prevState: T | undefined) => unknown): () => void

--- a/packages/incubator/react-extras/src/slice.tsx
+++ b/packages/incubator/react-extras/src/slice.tsx
@@ -8,14 +8,7 @@ export const useSelector = <T, U>(
   atom: Atom<T>,
   selector: (value: T) => U = identity as (value: T) => U,
   equals = Object.is
-) =>
-  useSyncExternalStoreWithSelector(
-    atom.subscribe,
-    () => atom.value,
-    () => atom.value,
-    selector,
-    equals
-  )
+) => useSyncExternalStoreWithSelector(atom.subscribe, atom.get, atom.get, selector, equals)
 
 const getKeys = <T,>(item: T) =>
   Array.isArray(item) ? item.map((_, i) => i) : Object.keys(item as any)

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -74,11 +74,7 @@ export function useAtom<T, U>(
 ): [T, U] | T {
   const atom =
     useConstant(() => typeof maybeAtom === 'function' && maybeAtom()) || (maybeAtom as Atom<T>)
-  const value = useSyncExternalStore(
-    atom.subscribe,
-    () => atom.value,
-    () => atom.value
-  )
+  const value = useSyncExternalStore(atom.subscribe, atom.get, atom.get)
   useDebugValue(value)
   // TODO: reserve the second argument for an equality checker function in the next versions
   return withActions ? ([value, (atom as any).actions] as [T, U]) : (value as T)

--- a/packages/xoid/src/internal/lite.tsx
+++ b/packages/xoid/src/internal/lite.tsx
@@ -3,6 +3,7 @@
 
 export type LiteAtom<T> = {
   value: T
+  get(): T
   set(state: T): void
   update(fn: (state: T) => T): void
   subscribe(fn: (value: T, previousValue: T) => void): () => void
@@ -91,7 +92,8 @@ export const createBaseApi = <T,>(internal: Internal<T>) => {
     set value(item) {
       api.set(item)
     },
-    set: (value: any) => set(value),
+    get,
+    set,
     update: (fn: any) => api.set(fn(get())),
     subscribe: (item) => subscribeInternal(subscribe, item, get),
     watch: (item) => subscribeInternal(subscribe, item, get, true),

--- a/packages/xoid/src/types.tsx
+++ b/packages/xoid/src/types.tsx
@@ -3,6 +3,7 @@ type Destructor = () => void | { [voidOnly]: never }
 
 export type Atom<T> = {
   value: T
+  get(): T
   set(state: T): void
   update(fn: (state: T) => T): void
   subscribe(fn: (state: T, prevState: T) => void | Destructor): () => void
@@ -15,6 +16,7 @@ export type Atom<T> = {
 
 export type Stream<T> = {
   value: T | undefined
+  get(): T | undefined
   set(state: T): void
   update(fn: (state: T | undefined) => T): void
   subscribe(fn: (state: T, prevState: T | undefined) => void | Destructor): () => void

--- a/tests/__snapshots__/actions.test.tsx.snap
+++ b/tests/__snapshots__/actions.test.tsx.snap
@@ -11,6 +11,7 @@ Object {
   "getSerialized": "{\\"count\\":1}",
   "self": Object {
     "focus": [Function],
+    "get": [Function],
     "map": [Function],
     "set": [Function],
     "subscribe": [Function],
@@ -43,6 +44,7 @@ Object {
   "getSerialized": "{\\"count\\":1}",
   "self": Object {
     "focus": [Function],
+    "get": [Function],
     "map": [Function],
     "set": [Function],
     "subscribe": [Function],

--- a/tests/__snapshots__/derived.test.tsx.snap
+++ b/tests/__snapshots__/derived.test.tsx.snap
@@ -7,6 +7,7 @@ Object {
   "getSerialized": "8",
   "self": Object {
     "focus": [Function],
+    "get": [Function],
     "map": [Function],
     "set": [Function],
     "subscribe": [Function],
@@ -33,6 +34,7 @@ Object {
   "getSerialized": "8",
   "self": Object {
     "focus": [Function],
+    "get": [Function],
     "map": [Function],
     "set": [Function],
     "subscribe": [Function],
@@ -59,6 +61,7 @@ Object {
   "getSerialized": "8",
   "self": Object {
     "focus": [Function],
+    "get": [Function],
     "map": [Function],
     "set": [Function],
     "subscribe": [Function],

--- a/tests/__snapshots__/lazy.test.tsx.snap
+++ b/tests/__snapshots__/lazy.test.tsx.snap
@@ -7,6 +7,7 @@ Object {
   "getSerialized": "5",
   "self": Object {
     "focus": [Function],
+    "get": [Function],
     "map": [Function],
     "set": [Function],
     "subscribe": [Function],


### PR DESCRIPTION
This one may be a little controversial, and I respect that you might have thought of this and ultimately preferred only having the `.value` getter. I personally prefer `.get()` as it nicely mirrors `.set(...)` and I honestly have found the Xoid API to be a little surprising without it.

However, this goes a little beyond personal preference because without a stable `.get()` method, we have been required to pass a new function to `useSyncExternalStore` every time, which means we must pay the small penalty of scheduling a layout effect to re-check the snapshot on every render. It's easy to see this in the shim [here](https://github.com/facebook/react/blob/main/packages/use-sync-external-store/src/useSyncExternalStoreShimClient.js#L89-L101) (as well as for `useSyncExternalStoreWithSelector` [here](https://github.com/facebook/react/blob/main/packages/use-sync-external-store/src/useSyncExternalStoreWithSelector.js#L112)), and the same is true for the real React hook (see [here](https://github.com/facebook/react/blob/main/packages/react-reconciler/src/ReactFiberHooks.js#L1842)).

So, ultimately I think it's worth having `.get()` for the slight performance benefit (it adds up for hundreds of components relying on atoms) and to satisfy some folks' personal preferences (I'm sure I won't be the only one). 😀