### PR TITLE
Fix: "Stale value in useSetup" #32

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoid/react",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -23,8 +23,8 @@ export function useSetup(fn: ($props?: any) => any, props?: any): any {
   /* eslint-disable react-hooks/rules-of-hooks */
   let result
   if (arguments.length > 1) {
-    const $props = useConstant(() => atom(() => props))
-    useIsoLayoutEffect(() => ($props as Atom<any>).set(props), [props])
+    const $props = useConstant(() => atom(props))
+    $props.set(props)
     result = useAdapter(() => fn($props))
   } else {
     result = useAdapter(fn)

--- a/tests/stale-props.test.tsx
+++ b/tests/stale-props.test.tsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import { act, render } from '@testing-library/react'
+import { atom, Atom } from 'xoid'
+import { useSetup } from '@xoid/react'
+
+describe('useSetup stale props issue', () => {
+  it('reproduces stale props issue in useSetup', async () => {
+    let capturedDisabled: boolean | undefined
+
+    function TestComponent({ disabled }: { disabled: boolean }) {
+      const { checkDisabled } = useSetup(
+        $p => {
+          return {
+            checkDisabled: () => {
+              capturedDisabled = $p.value.disabled
+            },
+          }
+        },
+        { disabled }
+      )
+
+      // React.useLayoutEffect(() => {
+      //   if (disabled) {
+      //     checkDisabled()
+      //   }
+      // }, [disabled, checkDisabled])
+
+      if (disabled && capturedDisabled === false) {
+        checkDisabled()
+      }
+
+      return <button onClick={checkDisabled}>Click me</button>
+    }
+
+    const { getByText, rerender } = render(<TestComponent disabled={false} />)
+
+    // Initial check
+    act(() => {
+      getByText('Click me').click()
+    })
+    expect(capturedDisabled).toBe(false)
+
+    // Rerender with disabled=true
+    act(() => {
+      rerender(<TestComponent disabled={true} />)
+    })
+
+    // This is expected to FAIL if the issue exists (it will be false instead of true)
+    // because useIsoLayoutEffect might not have updated the atom yet when the click happens,
+    // OR because of how the atom is being updated.
+    console.log('capturedDisabled after rerender (LayoutEffect):', capturedDisabled)
+    expect(capturedDisabled).toBe(true)
+  })
+
+  it('verifies useAltSetup fixes the issue', async () => {
+    let capturedDisabled: boolean | undefined
+
+    function useAltSetup<T, U>(setup: ($: Atom<T>) => U, p: T): U {
+      const $ = React.useMemo(() => atom(p), [])
+      // React.useEffect(() => $.set(p), [p]);
+      $.set(p) // Update during render
+      return React.useMemo(() => setup($), [])
+    }
+
+    function TestComponent({ disabled }: { disabled: boolean }) {
+      const { checkDisabled } = useAltSetup(
+        $p => {
+          return {
+            checkDisabled: () => {
+              capturedDisabled = $p.value.disabled
+            },
+          }
+        },
+        { disabled }
+      )
+
+      if (disabled && (capturedDisabled === false || capturedDisabled === undefined)) {
+        checkDisabled()
+      }
+
+      return <button onClick={checkDisabled}>Click me</button>
+    }
+
+    const { getByText, rerender } = render(<TestComponent disabled={false} />)
+
+    // Initial check
+    act(() => {
+      getByText('Click me').click()
+    })
+    expect(capturedDisabled).toBe(false)
+
+    // Rerender with disabled=true
+    act(() => {
+      rerender(<TestComponent disabled={true} />)
+    })
+
+    expect(capturedDisabled).toBe(true)
+  })
+})

--- a/tests/stale-props.test.tsx
+++ b/tests/stale-props.test.tsx
@@ -45,10 +45,7 @@ describe('useSetup stale props issue', () => {
       rerender(<TestComponent disabled={true} />)
     })
 
-    // This is expected to FAIL if the issue exists (it will be false instead of true)
-    // because useIsoLayoutEffect might not have updated the atom yet when the click happens,
-    // OR because of how the atom is being updated.
-    console.log('capturedDisabled after rerender (LayoutEffect):', capturedDisabled)
+    // This is expected to FAIL if the issue was not fixed
     expect(capturedDisabled).toBe(true)
   })
 
@@ -57,7 +54,6 @@ describe('useSetup stale props issue', () => {
 
     function useAltSetup<T, U>(setup: ($: Atom<T>) => U, p: T): U {
       const $ = React.useMemo(() => atom(p), [])
-      // React.useEffect(() => $.set(p), [p]);
       $.set(p) // Update during render
       return React.useMemo(() => setup($), [])
     }
@@ -95,5 +91,88 @@ describe('useSetup stale props issue', () => {
     })
 
     expect(capturedDisabled).toBe(true)
+  })
+
+  it('reproduces the specific issue reported by the user', async () => {
+    let capturedDisabledInsideCallback: boolean | undefined
+
+    function Child({ onValue, disabled }: { onValue: (v: number) => void; disabled: boolean }) {
+      if (disabled) {
+        onValue(10)
+      }
+      return null
+    }
+
+    function TestComponent({
+      disabled,
+      onChange,
+    }: {
+      disabled: boolean
+      onChange: (v: number) => void
+    }) {
+      const { onValue } = useSetup(
+        $p => {
+          return {
+            onValue: (v: number) => {
+              capturedDisabledInsideCallback = $p.value.disabled
+              if (!$p.value.disabled) {
+                $p.value.onChange(v)
+              }
+            },
+          }
+        },
+        { disabled, onChange }
+      )
+
+      return <Child onValue={onValue} disabled={disabled} />
+    }
+
+    const onChange = (v: number) => {}
+
+    const { rerender } = render(<TestComponent disabled={false} onChange={onChange} />)
+
+    // Rerender with disabled=true. Child will call onValue(10) during render.
+    act(() => {
+      rerender(<TestComponent disabled={true} onChange={onChange} />)
+    })
+
+    expect(capturedDisabledInsideCallback).toBe(true)
+  })
+
+  it('reproduces the reporter specific snippet and distinguishes between atom and closure variable', async () => {
+    let capturedAtomDisabled: boolean | undefined
+    let capturedClosureDisabled: boolean | undefined
+
+    function TestComponent({ disabled }: { disabled: boolean }) {
+      const { check } = useSetup(
+        ($p => {
+          // This 'p' is captured from the first render
+          const p = $p.value
+          return {
+            check: () => {
+              capturedAtomDisabled = $p.value.disabled
+              capturedClosureDisabled = p.disabled
+            },
+          }
+        }) as any,
+        { disabled }
+      )
+
+      if (disabled && capturedAtomDisabled === undefined) {
+        check()
+      }
+
+      return null
+    }
+
+    const { rerender } = render(<TestComponent disabled={false} />)
+
+    // Rerender with disabled=true
+    act(() => {
+      rerender(<TestComponent disabled={true} />)
+    })
+
+    expect(capturedAtomDisabled).toBe(true)
+    expect(capturedClosureDisabled).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
This PR fixes a "stale props" issue described in #32 
In the previous implementation of `useSetup`, the props atom was updated using `useIsoLayoutEffect`:

```typescript
// packages/react/src/index.tsx
const $props = useConstant(() => atom(() => props))
useIsoLayoutEffect(() => ($props as Atom<any>).set(props), [props])
```

Because `useIsoLayoutEffect` runs **after** the render phase, there was a timing gap. If a component rerendered with new props, any logic triggered during that same render (such as conditional checks in the component body or other hooks relying on the setup's return value) would access the `$props` atom before it had been updated with the new values.

## The Fix
The fix moves the atom update from `useIsoLayoutEffect` directly into the **render phase**. By calling `$props.set(props)` during render, we ensure that the atom always contains the most recent props before any other logic in the component or the setup function can access them.

```typescript
// Proposed change in packages/react/src/index.tsx
const $props = useConstant(() => atom(props))
$props.set(props) // Update synchronously during render
```

This pattern is safe in `xoid` because updating an atom does not trigger a React state update unless a listener is explicitly hooked into it, and here the update happens before the `useAdapter` logic evaluates the setup function.
