### PR TITLE
Add JSDoc comments to enhance the self-documenting aspect

### DIFF
--- a/packages/reactive/src/index.tsx
+++ b/packages/reactive/src/index.tsx
@@ -18,6 +18,9 @@ const map = new WeakMap()
 const isPrimitive = (obj: any) =>
   !(typeof obj === 'function' || typeof obj === 'object') || obj === null
 
+/**
+ * Converts an atom to a reactive proxy.
+ */
 export const toReactive = <T,>(a: Atom<T>): Reactive<T> => {
   const { value } = a
   if (isPrimitive(value)) return value as Reactive<T>
@@ -64,10 +67,19 @@ export const toReactive = <T,>(a: Atom<T>): Reactive<T> => {
   return proxy as Reactive<T>
 }
 
+/**
+ * Creates a reactive proxy.
+ */
 export const reactive = <T,>(initialValue: T): Reactive<T> => toReactive(atom(initialValue))
 
+/**
+ * Converts a reactive proxy to an atom.
+ */
 export const toAtom = <T,>(proxy: T): Atom<T> => proxy[IS_PROXY]
 
+/**
+ * Watches a function that uses reactive proxies.
+ */
 export const watch = (fn: () => void | Destructor) => {
   let cleanup
   const clean = () => {
@@ -89,6 +101,9 @@ export const watch = (fn: () => void | Destructor) => {
 
 // @ts-ignore
 const INTERNAL = tools.symbol
+/**
+ * Creates a computed atom from a function that uses reactive proxies.
+ */
 export const computed = <T,>(fn: () => T): Atom<T> => {
   const a = atom(fn)
   a[INTERNAL].track = true

--- a/packages/xoid/src/atom.tsx
+++ b/packages/xoid/src/atom.tsx
@@ -4,11 +4,21 @@ import { createSelector } from './internal/createSelector'
 
 /**
  * Creates an atom with the first argument as the initial state.
+ * If the first argument is a function, it creates a computed atom (selector).
  * Second argument can be used to attach actions to the atom.
  * @see [xoid.dev/docs/quick-tutorial](https://xoid.dev/docs/quick-tutorial)
  */
 export function atom<T>(init: Init<T>): Atom<T>
+/**
+ * Creates an atom with the first argument as the initial state.
+ * If the first argument is a function, it creates a computed atom (selector).
+ * Second argument can be used to attach actions to the atom.
+ * @see [xoid.dev/docs/quick-tutorial](https://xoid.dev/docs/quick-tutorial)
+ */
 export function atom<T, U>(init: Init<T>, getActions?: (a: Atom<T>) => U): Atom<T> & Actions<U>
+/**
+ * Creates an empty stream.
+ */
 export function atom<T>(): Stream<T>
 export function atom<T, U = undefined>(init?: Init<T>, getActions?: (a: Atom<T>) => U) {
   // @ts-ignore

--- a/packages/xoid/src/internal/types.tsx
+++ b/packages/xoid/src/internal/types.tsx
@@ -1,23 +1,65 @@
 export type Atom<T> = {
+  /**
+   * The current value of the atom.
+   */
   value: T
+  /**
+   * Sets the value of the atom.
+   */
   set(state: T): void
+  /**
+   * Updates the value of the atom using a updater function.
+   */
   update(fn: (state: T) => T): void
+  /**
+   * Subscribes to the atom WITHOUT calling with the current value at the start.
+   */
   subscribe(fn: (state: T, prevState: T) => void | Destructor): () => void
+  /**
+   * Subscribes to the atom. It calls the callback with the current value once at the start.
+   */
   watch(fn: (state: T, prevState: T) => void | Destructor): () => void
+  /**
+   * Focuses on a part of the atom's state.
+   */
   focus<U>(fn: (state: T) => U): Atom<U>
   focus<U extends keyof T>(key: U): Atom<T[U]>
+  /**
+   * Creates a derived atom from the current atom.
+   */
   map<U>(fn: (state: T, prevState: T) => U): Atom<U>
   map<U>(fn: (state: T, prevState: T) => U, filterOutFalsyValues: true): Stream<Truthy<U>>
 }
 
 export type Stream<T> = {
+  /**
+   * The current value of the stream.
+   */
   value: T | undefined
+  /**
+   * Sets the value of the stream.
+   */
   set(state: T): void
+  /**
+   * Updates the value of the stream using a updater function.
+   */
   update(fn: (state: T | undefined) => T): void
+  /**
+   * Subscribes to the stream WITHOUT calling with the current value at the start.
+   */
   subscribe(fn: (state: T, prevState: T | undefined) => void | Destructor): () => void
+  /**
+   * Subscribes to the atom WITHOUT calling with the current value at the start.
+   */
   watch(fn: (state: T | undefined, prevState: T | undefined) => void | Destructor): () => void
+  /**
+   * Subscribes to the atom. It calls the callback with the current value once at the start.
+   */
   focus<U>(fn: (state: T) => U): Stream<U>
   focus<U extends keyof T>(key: U): Stream<T[U]>
+  /**
+   * Creates a derived stream from the current stream.
+   */
   map<U>(fn: (state: T, prevState: T | undefined) => U): Stream<U>
   map<U>(
     fn: (state: T, prevState: T | undefined) => U,
@@ -25,13 +67,22 @@ export type Stream<T> = {
   ): Stream<Truthy<U>>
 }
 
+/**
+ * The `get` function passed to computed atoms.
+ */
 export type GetState = {
   <T>(atom: Atom<T>): T
   <T>(getState: () => T, subscribe: (fn: () => void) => () => void): T
 }
 
+/**
+ * Initial value or evaluation function for an atom.
+ */
 export type Init<T> = T | ((get: GetState) => T)
 
+/**
+ * Attached actions for an atom.
+ */
 export type Actions<U> = { actions: U; debugValue?: string }
 
 export type Truthy<T> = Exclude<T, false | 0 | '' | null | undefined>


### PR DESCRIPTION
## Summary
This PR adds comprehensive JSDoc documentation to the core methods and types in the `xoid` and `@xoid/reactive` packages. It arised from the need to specifically addressing the common confusion between `subscribe()` and `watch()`, that was requested in the issue https://github.com/xoidlabs/xoid/issues/31.

### Key Changes:
- **Clarified `subscribe` vs `watch`**: Added explicit notes that `subscribe()` does not trigger an initial call, while `watch()` calls the callback with the current value immediately upon subscription.
- **`Atom` & `Stream` Types**: Added documentation for `value`, `set()`, `update()`, `focus()`, and `map()`.
- **`@xoid/reactive`**: Added JSDoc for `reactive()`, `watch()`, `computed()`, `toReactive()`, and `toAtom()`.
- **Supporting Types**: Added descriptions for `GetState`, `Init`, and `Actions`.
