### PR TITLE
Implement `prefill`

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ With this feature, you can effectively replace the following framework-specific 
 
 |  | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/logo-plain.svg" width="16"/> xoid | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/integrations/react.ico" width="16"/> React | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/integrations/vue.png" width="16"/> Vue | <img src="https://raw.githubusercontent.com/xoidlabs/xoid/master/assets/integrations/svelte.png" width="16"/> Svelte |
 |---|---|---|---|---|
-| State | `create` | `useState` / `useReducer` | `reactive` / `shallowRef` | `readable` / `writable` |
-| Derived state | `create` | `useMemo` | `computed` | `derived` |
+| State | `atom` | `useState` / `useReducer` | `reactive` / `shallowRef` | `readable` / `writable` |
+| Derived state | `atom` | `useMemo` | `computed` | `derived` |
 | Lifecycle | `effect` | `useEffect` | `onMounted`, `onUnmounted` | `onMount`, `onDestroy` |
 | Dependency injection | `inject` | `useContext` | `inject` | `getContext` |
 
@@ -267,7 +267,7 @@ Import `@xoid/devtools` and set a `debugValue` to your atom. It will send values
 
 ```js
 import devtools from '@xoid/devtools'
-import create from 'xoid'
+import { atom } from 'xoid'
 devtools() // run once
 
 const $atom = atom(
@@ -291,7 +291,7 @@ atom.focus(s => s.alpha).set(25)  // "(myAtom) Update ([timestamp])
 
 ## Finite state machines
 
-No additional syntax is required for state machines. Just use the `create` function.
+No additional syntax is required for state machines. Just use the `atom` function.
 
 ```js
 import { atom } from 'xoid'

--- a/packages/prefill/README.md
+++ b/packages/prefill/README.md
@@ -7,6 +7,8 @@ A tiny utility for **preconfiguring React components** by “prefilling” (part
 - **Merges `className`** (default behavior)
 - Advanced mode: When the second argument is a function instead of an object, it can be used to compose props *before* they reach a component, to rename or filter them.
 
+See the release article [here](https://xoid.dev/blog/introducing-prefill).
+
 ---
 
 ## Install

--- a/packages/prefill/README.md
+++ b/packages/prefill/README.md
@@ -5,15 +5,13 @@ A tiny utility for **preconfiguring React components** by “prefilling” (part
 - Works with **intrinsic elements** (`'div'`, `'button'`, …) and **function components**
 - **Forwards refs** automatically
 - **Merges `className`** (default behavior)
-- Optional advanced mode: When the second argument is a function, and it can be used to compose props *before* they reach a component, to rename or filter props.
+- Advanced mode: When the second argument is a function instead of an object, it can be used to compose props *before* they reach a component, to rename or filter them.
 
 ---
 
 ## Install
 
 ```bash
-yarn add @xoid/prefill
-# or
 npm i @xoid/prefill
 ```
 
@@ -145,15 +143,3 @@ Your plugin is called as:
 ```
 
 and may mutate `nextProps` (e.g. to merge `className`, `style`, event handlers, etc.).
-
----
-
-## Notes / limitations
-
-- The implementation optimizes non-intrinsic components by calling them directly (instead of `React.createElement`). This is great for **function components**, but **class components are not supported** (calling a class component as a function will throw).
-
----
-
-## More
-
-There’s a longer write-up with motivation and patterns in `packages/prefill/ARTICLE.md`.

--- a/packages/prefill/README.md
+++ b/packages/prefill/README.md
@@ -1,4 +1,4 @@
-# `@xoid/prefill`
+# `prefill`: Partial Application for React Components
 
 A tiny utility for **preconfiguring React components** by “prefilling” (partially applying) props.
 

--- a/packages/prefill/README.md
+++ b/packages/prefill/README.md
@@ -1,0 +1,159 @@
+# `@xoid/prefill`
+
+A tiny utility for **preconfiguring React components** by “prefilling” (partially applying) props.
+
+- Works with **intrinsic elements** (`'div'`, `'button'`, …) and **function components**
+- **Forwards refs** automatically
+- **Merges `className`** (default behavior)
+- Optional advanced mode: When the second argument is a function, and it can be used to compose props *before* they reach a component, to rename or filter props.
+
+---
+
+## Install
+
+```bash
+yarn add @xoid/prefill
+# or
+npm i @xoid/prefill
+```
+
+`react` must be available in your project (this package expects React as a peer-dependency).
+
+---
+
+## Basic usage (object options)
+
+Prefill some props and get a new component where those props become optional.
+
+```ts
+import { prefill } from '@xoid/prefill'
+
+const OutlinedButton = prefill('button', { className: 'btn btn-outlined' })
+
+// `type` is now optional for consumers
+;(() => <OutlinedButton className="my-extra" />)()
+```
+
+### With an existing component
+
+```ts
+import { prefill } from '@xoid/prefill'
+import { Button } from './Button'
+
+const PrimaryButton = prefill(Button, { variant: 'primary' })
+```
+
+---
+
+## Function options (extras → pass-down) + prop filtering
+
+When the second argument is a function, it receives a **proxy** of the incoming props.
+
+**Any prop you read inside that function is treated as “extra” and will NOT be passed down** to the underlying element/component.
+
+This makes it easy to:
+- create custom props without leaking them to the DOM
+- adapt/rename props
+- compute pass-down props based on extras
+
+```ts
+import { prefill } from '@xoid/prefill'
+
+type InputExtras = { onValueChange: (value: string) => void }
+
+const Input = prefill('input', (props: InputExtras) => ({
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => props.onValueChange(e.target.value),
+}))
+
+// `onValueChange` is used to create `onChange`, and is NOT passed to <input/>
+;(() => <Input onValueChange={(v) => console.log(v)} />)()
+```
+
+### Filtering rule (exactly)
+
+- If `options` is an **object**: nothing is filtered.
+- If `options` is a **function**: props accessed inside it are removed from the props that get passed down.
+
+---
+
+## `className` merging
+
+By default, if both prefilled options and incoming props provide `className`, they are concatenated:
+
+```ts
+const Box = prefill('div', { className: 'base' })
+;(() => <Box className="extra" />)() // final className: "base extra"
+```
+
+---
+
+## Refs
+
+The returned component is `React.forwardRef(...)` and will pass the ref down as `ref`.
+
+```ts
+const Input = prefill('input', { className: 'field' })
+
+function Example() {
+  const ref = React.useRef<HTMLInputElement>(null)
+  return <Input ref={ref} />
+}
+```
+
+---
+
+## API
+
+### `prefill(as, options)`
+
+- **`as`**: an intrinsic element key (like `'div'`, `'input'`) or a React component.
+- **`options`**:
+  - an object of prefilled props, or
+  - a function `(extras) => passDownProps` (see “Function options” above)
+
+Named + default export are both provided:
+
+```ts
+import prefill, { prefill as namedPrefill } from '@xoid/prefill'
+```
+
+---
+
+## Advanced: custom merge “plugin”
+
+Internally, `prefill` calls a “plugin” function to post-process/merge props. By default it only merges `className`.
+
+You can provide your own plugin by calling `prefill` with a custom `this`:
+
+```ts
+import { prefill } from '@xoid/prefill'
+
+const mergeStyle = (left: { style?: React.CSSProperties }, right: { style?: React.CSSProperties }) => {
+  if (left.style && right.style) right.style = { ...left.style, ...right.style }
+}
+
+const styled = prefill.bind(mergeStyle)
+
+const Box = styled('div', { style: { padding: 8 } })
+;(() => <Box style={{ color: 'tomato' }} />)() // style => { padding: 8, color: 'tomato' }
+```
+
+Your plugin is called as:
+
+```ts
+(nextOptions, nextProps) => void
+```
+
+and may mutate `nextProps` (e.g. to merge `className`, `style`, event handlers, etc.).
+
+---
+
+## Notes / limitations
+
+- The implementation optimizes non-intrinsic components by calling them directly (instead of `React.createElement`). This is great for **function components**, but **class components are not supported** (calling a class component as a function will throw).
+
+---
+
+## More
+
+There’s a longer write-up with motivation and patterns in `packages/prefill/ARTICLE.md`.

--- a/packages/prefill/package.json
+++ b/packages/prefill/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@xoid/prefill",
+  "version": "0.0.1",
+  "main": "./index.js",
+  "module": "./index.esm.js",
+  "types": "./index.d.ts",
+  "sideEffects": false,
+  "description": "A tiny utility for preconfiguring React components by prefilling props",
+  "author": "onurkerimov",
+  "homepage": "https://xoid.dev",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xoidlabs/xoid",
+    "directory": "./packages/prefill"
+  },
+  "license": "MIT",
+  "peerDependencies": {
+    "react": ">=18.0.0"
+  }
+}

--- a/packages/prefill/package.json
+++ b/packages/prefill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xoid/prefill",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",

--- a/packages/prefill/src/index.tsx
+++ b/packages/prefill/src/index.tsx
@@ -51,11 +51,22 @@ const classNamePlugin = (left: { className?: string }, right: { className?: stri
   if (cx1 && cx2) right.className = `${cx1} ${cx2}`
 }
 
+const stylePlugin = (left: { style?: any }, right: { style?: any }) => {
+  const { style: s1 } = left
+  const { style: s2 } = right
+  if (s1 && s2) right.style = { ...s1, ...s2 }
+}
+
+const defaultPlugin = (left: any, right: any) => {
+  classNamePlugin(left, right)
+  stylePlugin(left, right)
+}
+
 export const prefill = function (this: any, as: any, options: any) {
   return React.forwardRef((props, ref) => {
     const [nextOptions, nextProps] = getPassdownProps(options, props)
     if (ref) nextProps.ref = ref
-    ;(this || classNamePlugin)(nextOptions, nextProps)
+    ;(this || defaultPlugin)(nextOptions, nextProps)
     const finalProps = Object.assign(nextOptions, nextProps)
     // Avoid extra `React.createElement` call if it's a non-intrinsic element
     // This is also good for React Devtools

--- a/packages/prefill/src/index.tsx
+++ b/packages/prefill/src/index.tsx
@@ -63,7 +63,7 @@ const defaultPlugin = (left: any, right: any) => {
 }
 
 export const prefill = function (this: any, as: any, options: any) {
-  return React.forwardRef((props, ref) => {
+  const Component = React.forwardRef((props, ref) => {
     const [nextOptions, nextProps] = getPassdownProps(options, props)
     if (ref) nextProps.ref = ref
     ;(this || defaultPlugin)(nextOptions, nextProps)
@@ -72,6 +72,10 @@ export const prefill = function (this: any, as: any, options: any) {
     // This is also good for React Devtools
     return typeof as === 'function' ? as(finalProps) : React.createElement(as, finalProps)
   })
+
+  Component.displayName = `Prefill(${as.displayName || as.name || 'Component'})`
+
+  return Component
 } as Box
 
 export default prefill

--- a/packages/prefill/src/index.tsx
+++ b/packages/prefill/src/index.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+
+export type ComponentType = keyof JSX.IntrinsicElements | React.JSXElementConstructor<any>
+
+export type Optional<T, U extends PropertyKey> = Omit<T, Extract<keyof T, U>> &
+  Partial<Pick<T, Extract<keyof T, U>>>
+
+export type PropsOf<T extends ComponentType, BoxProps> = React.ComponentProps<T> & BoxProps
+
+export type Box<BoxProps = {}> = <
+  Extras,
+  PassDown extends Partial<PropsOf<T, BoxProps>>,
+  T extends ComponentType = 'div'
+>(
+  as: T,
+  options: PassDown | ((extras: Extras) => PassDown)
+) => <U = JSX.Element>(
+  props: Extras & Optional<Omit<PropsOf<T, BoxProps>, keyof Extras>, keyof PassDown>
+) => U
+
+const proxy = (item: any) => {
+  const set = new Set<string>()
+  const proxy = new Proxy(item, {
+    get(target, key) {
+      set.add(key as string)
+      return Reflect.get(target, key)
+    },
+  })
+  return [proxy, set] as const
+}
+
+const omit = (object: any, set: Set<string>) => {
+  set.forEach(value => delete object[value])
+  return object
+}
+
+const getPassdownProps = (options: any, props: any) => {
+  if (typeof options === 'function') {
+    const [propsProxy, nonPassProps] = proxy(props)
+    const nextOptions = options(propsProxy)
+    const nextProps = omit({ ...props }, nonPassProps)
+    return [nextOptions, nextProps]
+  } else {
+    return [{ ...options }, { ...props }]
+  }
+}
+
+const classNamePlugin = (left: { className?: string }, right: { className?: string }) => {
+  const { className: cx1 } = left
+  const { className: cx2 } = right
+  if (cx1 && cx2) right.className = `${cx1} ${cx2}`
+}
+
+export const prefill = function (this: any, as: any, options: any) {
+  return React.forwardRef((props, ref) => {
+    const [nextOptions, nextProps] = getPassdownProps(options, props)
+    if (ref) nextProps.ref = ref
+    ;(this || classNamePlugin)(nextOptions, nextProps)
+    const finalProps = Object.assign(nextOptions, nextProps)
+    // Avoid extra `React.createElement` call if it's a non-intrinsic element
+    // This is also good for React Devtools
+    return typeof as === 'function' ? as(finalProps) : React.createElement(as, finalProps)
+  })
+} as Box
+
+export default prefill

--- a/packages/xoid/package.json
+++ b/packages/xoid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xoid",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./index.js",
   "module": "./index.esm.js",
   "types": "./index.d.ts",

--- a/tests/prefill.test.tsx
+++ b/tests/prefill.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { render, cleanup } from '@testing-library/react'
+import { prefill } from '@xoid/prefill'
+
+afterEach(cleanup)
+
+describe('prefill', () => {
+  it('should prefill props for an intrinsic element', () => {
+    const BlueDiv = prefill('div', { style: { color: 'blue' } })
+    const { getByText } = render(<BlueDiv>Hello</BlueDiv>)
+    const element = getByText('Hello')
+    expect(element.style.color).toBe('blue')
+  })
+
+  it('should merge classNames by default', () => {
+    const RedDiv = prefill('div', { className: 'red' })
+    const { getByText } = render(<RedDiv className="bold">Hello</RedDiv>)
+    const element = getByText('Hello')
+    expect(element.className).toBe('red bold')
+  })
+
+  it('should allow overriding prefilled props', () => {
+    const BlueDiv = prefill('div', { style: { color: 'blue' } })
+    const { getByText } = render(<BlueDiv style={{ color: 'red' }}>Hello</BlueDiv>)
+    const element = getByText('Hello')
+    // Now that stylePlugin is implemented, styles should be merged.
+    // The prop style { color: 'red' } should merge with prefilled { color: 'blue' }.
+    expect(element.style.color).toBe('red')
+  })
+
+  it('should merge style objects', () => {
+    const BlueDiv = prefill('div', { style: { color: 'blue', fontSize: '20px' } })
+    const { getByText } = render(<BlueDiv style={{ color: 'red', fontWeight: 'bold' }}>Hello</BlueDiv>)
+    const element = getByText('Hello')
+    expect(element.style.color).toBe('red')
+    expect(element.style.fontSize).toBe('20px')
+    expect(element.style.fontWeight).toBe('bold')
+  })
+
+  it('should support functional options for dynamic props', () => {
+    const DynamicDiv = prefill('div', (props: { isRed: boolean }) => ({
+      style: { color: props.isRed ? 'red' : 'blue' },
+    }))
+
+    const { getByText, rerender } = render(<DynamicDiv isRed={true}>Hello</DynamicDiv>)
+    expect(getByText('Hello').style.color).toBe('red')
+
+    rerender(<DynamicDiv isRed={false}>Hello</DynamicDiv>)
+    expect(getByText('Hello').style.color).toBe('blue')
+  })
+
+  it('should omit props used in functional options from being passed down', () => {
+    const MyComponent = jest.fn((props: any) => <div {...props} />)
+    const Prefilled = prefill(MyComponent, (props: { internal: string }) => ({
+      title: props.internal,
+    }))
+
+    render(<Prefilled internal="foo" other="bar" />)
+    
+    expect(MyComponent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: 'foo',
+        other: 'bar',
+      })
+    )
+    
+    // 'internal' should NOT be in the props passed to MyComponent
+    const calledProps = MyComponent.mock.calls[0][0]
+    expect(calledProps.internal).toBeUndefined()
+  })
+
+  it('should support custom plugin via `this` context', () => {
+    const customPlugin = jest.fn((options, props) => {
+      options.title = `Custom: ${props.name}`
+    })
+    
+    const Prefilled = prefill.call(customPlugin, 'div', {})
+    const { getByRole } = render(<Prefilled name="World" role="button" />)
+    
+    const element = getByRole('button')
+    expect(element.getAttribute('title')).toBe('Custom: World')
+    expect(customPlugin).toHaveBeenCalled()
+  })
+
+  it('should forward refs', () => {
+    const Prefilled = prefill('input', { type: 'text' })
+    const ref = React.createRef<HTMLInputElement>()
+    render(<Prefilled ref={ref} />)
+    expect(ref.current).toBeInstanceOf(HTMLInputElement)
+  })
+
+  it('should handle non-intrinsic elements correctly', () => {
+    const Inner = ({ label, ...props }: any) => <button {...props}>{label}</button>
+    const Prefilled = prefill(Inner, { label: 'Click me' })
+    const { getByText } = render(<Prefilled />)
+    expect(getByText('Click me').tagName).toBe('BUTTON')
+  })
+})


### PR DESCRIPTION
# Introducing **prefill**: A new primitive for composing React components

React lacks a proper “component preconfiguration” primitive. **prefill** is here to fix it. It's a tiny util that does **one thing** extremely well, in a declarative and type-safe manner.

Imagine you're styling a MaterialUI component, based on your site's styleguide. Usually it's done the following way:

```js
import styles from './StyledAccordion.module.css'

const StyledAccordion = (props: React.ComponentProps<typeof MuiAccordion>) => {
  return (
    <MuiAccordion 
      {...props}
      classes={{
        root: styles.root,
        paper: styles.paper,
      }} 
    />
  )
}
```

With **prefill**, it becomes:

```js
import styles from './StyledAccordion.module.css'
import { prefill } from 'prefill'

const StyledAccordion = prefill(MuiAccordion, {
  classes: {
    root: styles.root,
    paper: styles.paper,
  }
})
```

Here are the advantages of this example:
- No need to use `React.ComponentProps`, we know that it will be typesafe.
- No need to spread `{...props}`.
- Refs are passed automatically. No need for `forwardRef`, even in old React versions.

What we're doing here is **partial Application**.

Partial application means:

> Fixing some arguments of a function and producing a new function that accepts the rest.

**Example:**
```js
const add = (a, b) => a + b
const add5 = partial(add, 5) // (b) => 5 + b
```

At its core, **prefill** is a partial application mechanism built specifically for React components. It's not limited to styles. There are many more use cases that will be explained.